### PR TITLE
Харламова Анастасия

### DIFF
--- a/Create objects.sql
+++ b/Create objects.sql
@@ -89,56 +89,103 @@ GO
 SET QUOTED_IDENTIFIER ON
 GO
 
-CREATE FUNCTION [dbo].[F_WORKS_LIST] (
-)
+CREATE FUNCTION [dbo].[F_WORKS_LIST] ()
 RETURNS @RESULT TABLE
 (
-ID_WORK INT,
-CREATE_Date DATETIME,
-MaterialNumber DECIMAL(8,2),
-IS_Complit BIT,
-FIO VARCHAR(255),
-D_DATE varchar(10),
-WorkItemsNotComplit int,
-WorkItemsComplit int,
-FULL_NAME VARCHAR(101),
-StatusId smallint,
-StatusName VARCHAR(255),
-Is_Print bit
+    ID_WORK INT,
+    CREATE_Date DATETIME,
+    MaterialNumber INT,
+    IS_Complit BIT,
+    FIO VARCHAR(100),
+    D_DATE VARCHAR(10),
+    WorkItemsNotComplit INT,
+    WorkItemsComplit INT,
+    FULL_NAME VARCHAR(100),
+    StatusId INT,
+    StatusName VARCHAR(100),
+    Is_Print BIT
 )
 AS
--- СПИСОК РАБОТ
-begin
-insert into @result
-SELECT
-  Works.Id_Work,
-  Works.CREATE_Date,
-  Works.MaterialNumber,
-  Works.IS_Complit,
-  Works.FIO,
-  convert(varchar(10), works.CREATE_Date, 104 ) as D_DATE,
-  dbo.F_WORKITEMS_COUNT_BY_ID_WORK(works.Id_Work,0) as WorkItemsNotComplit,
-  dbo.F_WORKITEMS_COUNT_BY_ID_WORK(works.Id_Work,1) as WorkItemsComplit,
-  dbo.F_EMPLOYEE_FULLNAME(Works.Id_Employee) as EmployeeFullName,
-  Works.StatusId,
-  WorkStatus.StatusName,
-  case
-      when (Works.Print_Date is not null) or
-      (Works.SendToClientDate is not null) or
-      (works.SendToDoctorDate is not null) or
-      (Works.SendToOrgDate is not null) or
-      (Works.SendToFax is not null)
-      then 1
-      else 0
-  end as Is_Print  
-FROM
- Works
- left outer join WorkStatus on (Works.StatusId = WorkStatus.StatusID)
-where
- WORKS.IS_DEL <> 1
- order by id_work desc -- works.MaterialNumber desc
-return
-end
+BEGIN
+    DECLARE @CurrentEmployee INT;
+
+    SELECT @CurrentEmployee = dbo.F_EMPLOYEE_GET();
+
+    INSERT INTO @RESULT
+    SELECT
+        w.Id_Work,
+        w.CREATE_Date,
+        w.MaterialNumber,
+        w.IS_Complit,
+        w.FIO,
+        CONVERT(varchar(10), w.CREATE_Date, 104) AS D_DATE,
+
+        ISNULL(ic.WorkItemsNotComplit, 0) AS WorkItemsNotComplit,
+        ISNULL(ic.WorkItemsComplit, 0) AS WorkItemsComplit,
+
+        CASE
+            WHEN COALESCE(w.Id_Employee, @CurrentEmployee) = -1 THEN ''
+            WHEN fn.RawFullName = '' THEN e.Login_Name
+            ELSE fn.RawFullName
+        END AS FULL_NAME,
+
+        w.StatusId,
+        ws.StatusName,
+
+        CAST(
+            CASE
+                WHEN w.Print_Date IS NOT NULL
+                  OR w.SendToClientDate IS NOT NULL
+                  OR w.SendToDoctorDate IS NOT NULL
+                  OR w.SendToOrgDate IS NOT NULL
+                  OR w.SendToFax IS NOT NULL
+                THEN 1
+                ELSE 0
+            END
+        AS bit) AS Is_Print
+
+    FROM dbo.Works w
+
+    LEFT JOIN dbo.WorkStatus ws
+        ON w.StatusId = ws.StatusID
+
+    LEFT JOIN dbo.Employee e
+        ON e.Id_Employee = COALESCE(w.Id_Employee, @CurrentEmployee)
+
+    OUTER APPLY (
+        SELECT
+            RawFullName = RTRIM(REPLACE(
+                e.Surname + ' '
+                + UPPER(SUBSTRING(e.Name, 1, 1)) + '. '
+                + UPPER(SUBSTRING(e.Patronymic, 1, 1)) + '.',
+                '. .',
+                ''
+            ))
+    ) fn
+
+    LEFT JOIN (
+        SELECT
+            wi.Id_Work,
+            SUM(CASE WHEN wi.Is_Complit = 0 THEN 1 ELSE 0 END) AS WorkItemsNotComplit,
+            SUM(CASE WHEN wi.Is_Complit = 1 THEN 1 ELSE 0 END) AS WorkItemsComplit
+        FROM dbo.WorkItem wi
+        WHERE wi.ID_ANALIZ IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1
+              FROM dbo.Analiz a
+              WHERE a.ID_ANALIZ = wi.ID_ANALIZ
+                AND a.IS_GROUP = 1
+          )
+        GROUP BY wi.Id_Work
+    ) ic
+        ON ic.Id_Work = w.Id_Work
+
+    WHERE w.Is_Del <> 1
+
+    ORDER BY w.Id_Work DESC;
+
+    RETURN;
+END;
 
 GO
 /****** Object:  Table [dbo].[Analiz]    Script Date: 28.04.2024 19:21:25 ******/

--- a/Create objects.sql
+++ b/Create objects.sql
@@ -94,15 +94,15 @@ RETURNS @RESULT TABLE
 (
     ID_WORK INT,
     CREATE_Date DATETIME,
-    MaterialNumber INT,
+    MaterialNumber DECIMAL(8,2),
     IS_Complit BIT,
-    FIO VARCHAR(100),
+    FIO VARCHAR(255),
     D_DATE VARCHAR(10),
     WorkItemsNotComplit INT,
     WorkItemsComplit INT,
-    FULL_NAME VARCHAR(100),
+    FULL_NAME VARCHAR(101),
     StatusId INT,
-    StatusName VARCHAR(100),
+    StatusName VARCHAR(255),
     Is_Print BIT
 )
 AS

--- a/seed_data.sql
+++ b/seed_data.sql
@@ -1,0 +1,295 @@
+USE UDFOptimization;
+GO
+
+SET NOCOUNT ON;
+GO
+
+DELETE FROM dbo.WorkItem;
+DELETE FROM dbo.Works;
+DELETE FROM dbo.Organization;
+DELETE FROM dbo.Analiz;
+DELETE FROM dbo.Employee;
+DELETE FROM dbo.WorkStatus;
+DELETE FROM dbo.SelectType;
+GO
+
+/* WorkStatus: ID 1..5 */
+SET IDENTITY_INSERT dbo.WorkStatus ON;
+INSERT INTO dbo.WorkStatus (StatusID, StatusName)
+VALUES
+    (1, 'New'),
+    (2, 'In progress'),
+    (3, 'Ready'),
+    (4, 'Sent'),
+    (5, 'Closed');
+SET IDENTITY_INSERT dbo.WorkStatus OFF;
+GO
+
+/* SelectType: ID 1..3 */
+SET IDENTITY_INSERT dbo.SelectType ON;
+INSERT INTO dbo.SelectType (Id_SelectType, SelectType)
+VALUES
+    (1, 'Regular'),
+    (2, 'Urgent'),
+    (3, 'Repeat');
+SET IDENTITY_INSERT dbo.SelectType OFF;
+GO
+
+/* Employee: ID 1..20 */
+SET IDENTITY_INSERT dbo.Employee ON;
+
+;WITH nums AS (
+    SELECT TOP (20)
+        ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS n
+    FROM sys.all_objects
+)
+INSERT INTO dbo.Employee
+(
+    Id_Employee,
+    Login_Name,
+    Name,
+    Patronymic,
+    Surname,
+    Email,
+    Post,
+    CreateDate,
+    Archived,
+    IS_Role,
+    Role
+)
+SELECT
+    n,
+    CONCAT('employee', n),
+    CONCAT('Name', n),
+    CONCAT('Patronymic', n),
+    CONCAT('Surname', n),
+    CONCAT('employee', n, '@test.local'),
+    'Lab worker',
+    GETDATE(),
+    0,
+    0,
+    0
+FROM nums;
+
+SET IDENTITY_INSERT dbo.Employee OFF;
+GO
+
+/* Organization: ID 1..100 */
+SET IDENTITY_INSERT dbo.Organization ON;
+
+;WITH nums AS (
+    SELECT TOP (100)
+        ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS n
+    FROM sys.all_objects
+)
+INSERT INTO dbo.Organization
+(
+    ID_ORGANIZATION,
+    ORG_NAME,
+    Email,
+    Fax
+)
+SELECT
+    n,
+    CONCAT('Organization ', n),
+    CONCAT('org', n, '@test.local'),
+    CONCAT('+7900000', RIGHT(CONCAT('0000', n), 4))
+FROM nums;
+
+SET IDENTITY_INSERT dbo.Organization OFF;
+GO
+
+/* Analiz: ID 1..500 */
+SET IDENTITY_INSERT dbo.Analiz ON;
+
+;WITH nums AS (
+    SELECT TOP (500)
+        ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS n
+    FROM sys.all_objects a
+    CROSS JOIN sys.all_objects b
+)
+INSERT INTO dbo.Analiz
+(
+    ID_ANALIZ,
+    IS_GROUP,
+    MATERIAL_TYPE,
+    CODE_NAME,
+    FULL_NAME,
+    ID_ILL,
+    Text_Norm,
+    Price,
+    NormText,
+    UnNormText
+)
+SELECT
+    n,
+    CASE WHEN n % 20 = 0 THEN 1 ELSE 0 END,
+    n % 5,
+    CONCAT('A', n),
+    CONCAT('Analysis ', n),
+    NULL,
+    'Normal',
+    CAST(100 + (n % 400) AS DECIMAL(8, 2)),
+    'Normal text',
+    'Abnormal text'
+FROM nums;
+
+SET IDENTITY_INSERT dbo.Analiz OFF;
+GO
+
+/* Works: 50 000 заказов, ID 1..50000 */
+SET IDENTITY_INSERT dbo.Works ON;
+
+;WITH nums AS (
+    SELECT TOP (50000)
+        ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS n
+    FROM sys.all_objects a
+    CROSS JOIN sys.all_objects b
+)
+INSERT INTO dbo.Works
+(
+    Id_Work,
+    IS_Complit,
+    CREATE_Date,
+    Close_Date,
+    Id_Employee,
+    ID_ORGANIZATION,
+    Comment,
+    Print_Date,
+    Org_Name,
+    Part_Name,
+    Org_RegN,
+    Material_Type,
+    Material_Get_Date,
+    Material_Reg_Date,
+    MaterialNumber,
+    Material_Comment,
+    FIO,
+    PHONE,
+    EMAIL,
+    Is_Del,
+    Id_Employee_Del,
+    DelDate,
+    Price,
+    ExtRegN,
+    MedicalHistoryNumber,
+    DoctorFIO,
+    DoctorPhone,
+    OrganizationFax,
+    OrganizationEmail,
+    DoctorEmail,
+    StatusId,
+    SendToOrgDate,
+    SendToClientDate,
+    SendToDoctorDate,
+    SendToFax,
+    SendToApp
+)
+SELECT
+    n,
+    CASE WHEN n % 4 = 0 THEN 1 ELSE 0 END,
+    DATEADD(DAY, -(n % 365), GETDATE()),
+    CASE WHEN n % 4 = 0 THEN DATEADD(DAY, -(n % 365) + 1, GETDATE()) ELSE NULL END,
+    ((n - 1) % 20) + 1,
+    ((n - 1) % 100) + 1,
+    CONCAT('Comment for work ', n),
+    CASE WHEN n % 10 = 0 THEN DATEADD(DAY, -(n % 365) + 2, GETDATE()) ELSE NULL END,
+    CONCAT('Organization ', ((n - 1) % 100) + 1),
+    NULL,
+    NULL,
+    n % 5,
+    DATEADD(DAY, -(n % 365), GETDATE()),
+    DATEADD(DAY, -(n % 365), GETDATE()),
+    CAST(n AS DECIMAL(8, 2)),
+    NULL,
+    CONCAT('Patient ', n),
+    CONCAT('+7900', RIGHT(CONCAT('0000000', n), 7)),
+    CONCAT('patient', n, '@test.local'),
+    CASE WHEN n % 100 = 0 THEN 1 ELSE 0 END,
+    NULL,
+    NULL,
+    CAST(500 + (n % 3000) AS DECIMAL(8, 2)),
+    CONCAT('EXT', n),
+    CONCAT('MH', n),
+    CONCAT('Doctor ', ((n - 1) % 50) + 1),
+    CONCAT('+7911', RIGHT(CONCAT('0000000', n), 7)),
+    CONCAT('+7922', RIGHT(CONCAT('0000000', n), 7)),
+    CONCAT('org', ((n - 1) % 100) + 1, '@test.local'),
+    CONCAT('doctor', ((n - 1) % 50) + 1, '@test.local'),
+    CAST(((n - 1) % 5) + 1 AS SMALLINT),
+    CASE WHEN n % 15 = 0 THEN DATEADD(DAY, -(n % 365) + 2, GETDATE()) ELSE NULL END,
+    CASE WHEN n % 12 = 0 THEN DATEADD(DAY, -(n % 365) + 2, GETDATE()) ELSE NULL END,
+    CASE WHEN n % 18 = 0 THEN DATEADD(DAY, -(n % 365) + 2, GETDATE()) ELSE NULL END,
+    CASE WHEN n % 25 = 0 THEN DATEADD(DAY, -(n % 365) + 2, GETDATE()) ELSE NULL END,
+    CASE WHEN n % 30 = 0 THEN DATEADD(DAY, -(n % 365) + 2, GETDATE()) ELSE NULL END
+FROM nums;
+
+SET IDENTITY_INSERT dbo.Works OFF;
+GO
+
+/* WorkItem: 150 000 элементов заказов, по 3 на каждый заказ */
+SET IDENTITY_INSERT dbo.WorkItem ON;
+
+;WITH nums AS (
+    SELECT TOP (150000)
+        ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS n
+    FROM sys.all_objects a
+    CROSS JOIN sys.all_objects b
+)
+INSERT INTO dbo.WorkItem
+(
+    ID_WORKItem,
+    CREATE_DATE,
+    Is_Complit,
+    Close_Date,
+    Id_Employee,
+    ID_ANALIZ,
+    Id_Work,
+    Is_Print,
+    Is_Select,
+    Is_NormTextPrint,
+    Price,
+    Id_SelectType
+)
+SELECT
+    n,
+    DATEADD(DAY, -(n % 365), GETDATE()),
+    CASE WHEN n % 2 = 0 THEN 1 ELSE 0 END,
+    CASE WHEN n % 2 = 0 THEN DATEADD(DAY, -(n % 365) + 1, GETDATE()) ELSE NULL END,
+    ((n - 1) % 20) + 1,
+    ((n - 1) % 500) + 1,
+    ((n - 1) / 3) + 1,
+    1,
+    CASE WHEN n % 3 = 0 THEN 1 ELSE 0 END,
+    1,
+    CAST(100 + (n % 400) AS DECIMAL(8, 2)),
+    ((n - 1) % 3) + 1
+FROM nums;
+
+SET IDENTITY_INSERT dbo.WorkItem OFF;
+GO
+
+/* Обновим счётчики identity на будущее */
+DBCC CHECKIDENT ('dbo.WorkStatus', RESEED, 5);
+DBCC CHECKIDENT ('dbo.SelectType', RESEED, 3);
+DBCC CHECKIDENT ('dbo.Employee', RESEED, 20);
+DBCC CHECKIDENT ('dbo.Organization', RESEED, 100);
+DBCC CHECKIDENT ('dbo.Analiz', RESEED, 500);
+DBCC CHECKIDENT ('dbo.Works', RESEED, 50000);
+DBCC CHECKIDENT ('dbo.WorkItem', RESEED, 150000);
+GO
+
+SELECT 'Employee' AS table_name, COUNT(*) AS rows_count FROM dbo.Employee
+UNION ALL
+SELECT 'WorkStatus', COUNT(*) FROM dbo.WorkStatus
+UNION ALL
+SELECT 'SelectType', COUNT(*) FROM dbo.SelectType
+UNION ALL
+SELECT 'Organization', COUNT(*) FROM dbo.Organization
+UNION ALL
+SELECT 'Analiz', COUNT(*) FROM dbo.Analiz
+UNION ALL
+SELECT 'Works', COUNT(*) FROM dbo.Works
+UNION ALL
+SELECT 'WorkItem', COUNT(*) FROM dbo.WorkItem;
+GO


### PR DESCRIPTION

В исходной реализации F_WORKS_LIST() для каждой строки заказа дважды вызывалась функция F_WORKITEMS_COUNT_BY_ID_WORK(): отдельно для готовых и неготовых позиций. Из-за этого при выборке большого количества заказов выполнялось много повторных обращений к таблицам WorkItem и Analiz. Я заменила эту логику на один агрегирующий подзапрос с GROUP BY Id_Work, где оба счётчика считаются за один проход через SUM(CASE ...), а групповые анализы исключаются через NOT EXISTS.

Также в исходной функции для каждой строки вызывалась F_EMPLOYEE_FULLNAME(), внутри которой выполнялся отдельный запрос к Employee. В оптимизированной версии данные сотрудника получаются через LEFT JOIN, а формирование ФИО перенесено в основной запрос через OUTER APPLY.

После оптимизации был выполнен замер производительности через SET STATISTICS TIME ON и SET STATISTICS IO ON. Для исходного проверочного запроса SELECT COUNT( * ) FROM (SELECT TOP (3000) * FROM dbo.F_WORKS_LIST()) q старая функция выполнилась за 10909 ms, а оптимизированная версия — менее чем за 1 ms

Также для оптимизации можно:
- добавить столбцы-счётчики прямо в таблицу Works, тогда счётчики завершенных/ незавершенных заказов будут храниться в самом заказе
		- недостатки: таблица Works станет шире, появится риск неправильных значений счётчиков. При каждом добавлении, удалении или изменении WorkItem нужно будет обновлять соответствующие поля в Works. 
- если использовать новые столбцы в Works можно создать триггеры на WorkItem, они будут автоматически пересчитывать или корректировать счётчики.
		- Триггеры замедляют операции записи, логика становится скрытой (при выполнении INSERT в WorkItem автоматически меняется Works или WorkItemCounts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Chores**
  * Оптимизирована обработка данных в системе для улучшения производительности.
  * Добавлена инфраструктура инициализации тестового окружения базы данных.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sevryukov/UDF-optimization/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->